### PR TITLE
Easy custom cheat code implemention - with touch devices support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ This is why you do code reviews more often than once ever two years.
 
 To use your own custom cheat code you can use the `cheatCode()` function of the konami instance.
 
-  success = function() { 
-    console.log("Custom trigger!"); 
-  }
-  ko = new Konami(success);
-  ko.cheatCode(["LEFT", "RIGHT", "A", "B", "R", "RIGHT", "ENTER"]);
+	success = function() { 
+    		console.log("Custom trigger!"); 
+  	}
+  	ko = new Konami(success);
+  	ko.cheatCode(["LEFT", "RIGHT", "A", "B", "R", "RIGHT", "ENTER"]);
 
 `cheatCode()` automatically converts your cheat code into a format that can be used on touch devices as well.
 Direction keys are matched into swipes while uppercase letters and ENTER are matched into TAPS on touch devices.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ A passed string is assumed to be the URL to redirect to. A passed function will 
 This is why you do code reviews more often than once ever two years. 
 
 
+#### Custom Cheat Codes
+
+To use your own custom cheat code you can use the `cheatCode()` function of the konami instance.
+
+  success = function() { 
+    console.log("Custom trigger!"); 
+  }
+  ko = new Konami(success);
+  ko.cheatCode(["LEFT", "RIGHT", "A", "B", "R", "RIGHT", "ENTER"]);
+
+`cheatCode()` automatically converts your cheat code into a format that can be used on touch devices as well.
+Direction keys are matched into swipes while uppercase letters and ENTER are matched into TAPS on touch devices.
+The code array passed into `cheatCode()` must be one of `["UP", "DOWN", "LEFT", "RIGHT", "ENTER", [any uppercase letter from A-Z]`.
+
+
 #### Overview
 
 Every site should have an implementation of the Konami Code. It makes things more fun. If you're unfamiliar with it, the Konami Code is a "cheat code" that appeared in many of Konami's video games going all the way back to 1986.  It was typically entered on a Nintendo controller. Recently, ESPN received attention for the funny, flashy things that would happen when the code was entered on their website. Those shenanigans were the inspiration for whipping up this script.

--- a/konami.js
+++ b/konami.js
@@ -17,10 +17,10 @@ var Konami = function(callback) {
 			/**
 			 * This overrides the default cheat code of this konami instance.
 			 * Takes in an array of cheat codes that will be used for both default and touch devices.
-			 * Codes must be "UP", "DOWN", "LEFT", "RIGHT", "ENTER", or any single characters
+			 * Codes must be "UP", "DOWN", "LEFT", "RIGHT", "ENTER", or an uppercase letter
 			 * Example cheat code: ["UP", "DOWN", "LEFT", "RIGHT", "A", "C", "ENTER"]
 			 *
-			 * Note: When used on a mobile device, "ENTER" or any single characters just translate into a "TAP"
+			 * Note: When used on a mobile device, "ENTER" or any uppercase letter just translates into a "TAP"
 			 */
 			cheatCode: function(codeArray) {
 				// Adjust the code array for both our default code pattern and also iphone pattern
@@ -47,11 +47,15 @@ var Konami = function(callback) {
 						adjustedNormalCode += "13";
 						adjustedIphoneCode.push("TAP");
 					}else {
-						// If not in the list then we just use the char(code of the first letter)
-						adjustedNormalCode += code.charCodeAt(0).toString();
-						adjustedIphoneCode.push("TAP");
+						// Other than the above, only accepts upcase characters.
+						// If not an uppercase letter, then ignore code.
+						charCode = code.charCodeAt(0);
+						if (charCode >= 65 && charCode <= 90) {
+							adjustedNormalCode += charCode.toString();
+							adjustedIphoneCode.push("TAP");
+						}
 					}
-				};
+				}
 				this.pattern = adjustedNormalCode;
 				this.iphone.keys = adjustedIphoneCode;
 			},

--- a/konami.js
+++ b/konami.js
@@ -32,27 +32,27 @@ var Konami = function(callback) {
 				for (var i = 0; i < codeArray.length; i++) {
 					code = codeArray[i];
 					if (code === "UP") {
-						adjustedCode += "38"
+						adjustedNormalCode += "38"
 						adjustedIphoneCode.push(code)
 					}else if (code === "DOWN") {
-						adjustedCode += "40";
+						adjustedNormalCode += "40";
 						adjustedIphoneCode.push(code)
 					}else if (code === "LEFT") {
-						adjustedCode += "37";
+						adjustedNormalCode += "37";
 						adjustedIphoneCode.push(code)
 					}else if (code === "RIGHT") {
-						adjustedCode += "39";
+						adjustedNormalCode += "39";
 						adjustedIphoneCode.push(code)
 					}else if (code === "ENTER") {
-						adjustedCode += "13";
+						adjustedNormalCode += "13";
 						adjustedIphoneCode.push("TAP")
 					}else {
 						// If not in the list then we just use the char(code of the first letter)
-						adjustedCode += code.charCodeAt(0).toString();
+						adjustedNormalCode += code.charCodeAt(0).toString();
 						adjustedIphoneCode.push("TAP")
 					}
 				};
-				this.pattern = adjustedCode;
+				this.pattern = adjustedNormalCode;
 				this.iphone.keys = adjustedIphoneCode;
 			},
 			addEvent:function ( obj, type, fn, ref_obj )

--- a/konami.js
+++ b/konami.js
@@ -27,29 +27,29 @@ var Konami = function(callback) {
 				// The code for iphone should be pretty much same, except we change
 				// non-direction codes into just a tap.
 				adjustedNormalCode = "";
-				adjustedIphoneCode = []
+				adjustedIphoneCode = [];
 
 				for (var i = 0; i < codeArray.length; i++) {
 					code = codeArray[i];
 					if (code === "UP") {
-						adjustedNormalCode += "38"
-						adjustedIphoneCode.push(code)
+						adjustedNormalCode += "38";
+						adjustedIphoneCode.push(code);
 					}else if (code === "DOWN") {
 						adjustedNormalCode += "40";
-						adjustedIphoneCode.push(code)
+						adjustedIphoneCode.push(code);
 					}else if (code === "LEFT") {
 						adjustedNormalCode += "37";
-						adjustedIphoneCode.push(code)
+						adjustedIphoneCode.push(code);
 					}else if (code === "RIGHT") {
 						adjustedNormalCode += "39";
-						adjustedIphoneCode.push(code)
+						adjustedIphoneCode.push(code);
 					}else if (code === "ENTER") {
 						adjustedNormalCode += "13";
-						adjustedIphoneCode.push("TAP")
+						adjustedIphoneCode.push("TAP");
 					}else {
 						// If not in the list then we just use the char(code of the first letter)
 						adjustedNormalCode += code.charCodeAt(0).toString();
-						adjustedIphoneCode.push("TAP")
+						adjustedIphoneCode.push("TAP");
 					}
 				};
 				this.pattern = adjustedNormalCode;

--- a/konami.js
+++ b/konami.js
@@ -13,6 +13,48 @@
 
 var Konami = function(callback) {
 	var konami= {
+
+			/**
+			 * This overrides the default cheat code of this konami instance.
+			 * Takes in an array of cheat codes that will be used for both default and touch devices.
+			 * Codes must be "UP", "DOWN", "LEFT", "RIGHT", "ENTER", or any single characters
+			 * Example cheat code: ["UP", "DOWN", "LEFT", "RIGHT", "A", "C", "ENTER"]
+			 *
+			 * Note: When used on a mobile device, "ENTER" or any single characters just translate into a "TAP"
+			 */
+			cheatCode: function(codeArray) {
+				// Adjust the code array for both our default code pattern and also iphone pattern
+				// The code for iphone should be pretty much same, except we change
+				// non-direction codes into just a tap.
+				adjustedNormalCode = "";
+				adjustedIphoneCode = []
+
+				for (var i = 0; i < codeArray.length; i++) {
+					code = codeArray[i];
+					if (code === "UP") {
+						adjustedCode += "38"
+						adjustedIphoneCode.push(code)
+					}else if (code === "DOWN") {
+						adjustedCode += "40";
+						adjustedIphoneCode.push(code)
+					}else if (code === "LEFT") {
+						adjustedCode += "37";
+						adjustedIphoneCode.push(code)
+					}else if (code === "RIGHT") {
+						adjustedCode += "39";
+						adjustedIphoneCode.push(code)
+					}else if (code === "ENTER") {
+						adjustedCode += "13";
+						adjustedIphoneCode.push("TAP")
+					}else {
+						// If not in the list then we just use the char(code of the first letter)
+						adjustedCode += code.charCodeAt(0).toString();
+						adjustedIphoneCode.push("TAP")
+					}
+				};
+				this.pattern = adjustedCode;
+				this.iphone.keys = adjustedIphoneCode;
+			},
 			addEvent:function ( obj, type, fn, ref_obj )
 			{
 				if (obj.addEventListener)


### PR DESCRIPTION
Added a `cheatCode()` function to set custom cheat codes to a `Konami` instance. 
`cheatCodes()` handles converting the cheat code array into formats that can be used by `pattern` and `iphone.code`.
