### PR TITLE
Remove logging and correct typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ If you are looking for GamePad support check out this fork:
 
 ## Contributions
 
-Your pull requests are welcome! Emphasis on small footprints, speed and broad device/browser compatability. Less interested in package manger and toolchain integrations. 
+Your pull requests are welcome! Emphasis on small footprints, speed and broad device/browser compatability. Less interested in package manager and toolchain integrations. 

--- a/konami.js
+++ b/konami.js
@@ -33,7 +33,6 @@ var Konami = function (callback) {
         input: "",
         pattern: "38384040373937396665",
         keydownHandler: function (e, ref_obj) {
-            console.log(this)
             if (ref_obj) {
                 konami = ref_obj;
             } // IE


### PR DESCRIPTION
This removes console logging that occurs on every keypress that was added in #41 (presumably by accident).

It also corrects a typo I happened to notice.