### PR TITLE
Fix when importing as module

### DIFF
--- a/konami.js
+++ b/konami.js
@@ -10,142 +10,154 @@
  */
 
 var Konami = function (callback) {
-    var konami = {
-        addEvent: function (obj, type, fn, ref_obj) {
-            if (obj.addEventListener)
-                obj.addEventListener(type, fn, false);
-            else if (obj.attachEvent) {
-                // IE
-                obj["e" + type + fn] = fn;
-                obj[type + fn] = function () {
-                    obj["e" + type + fn](window.event, ref_obj);
-                }
-                obj.attachEvent("on" + type, obj[type + fn]);
-            }
-        },
-        removeEvent: function (obj, eventName, eventCallback) {
-            if (obj.removeEventListener) {
-                obj.removeEventListener(eventName, eventCallback);
-            } else if (obj.attachEvent) {
-                obj.detachEvent(eventName);
-            }
-        },
-        input: "",
-        pattern: "38384040373937396665",
-        keydownHandler: function (e, ref_obj) {
-            if (ref_obj) {
-                konami = ref_obj;
-            } // IE
-            konami.input += e ? e.keyCode : event.keyCode;
-            if (konami.input.length > konami.pattern.length) {
-                konami.input = konami.input.substr((konami.input.length - konami.pattern.length));
-            }
-            if (konami.input === konami.pattern) {
-                konami.code(konami._currentLink);
-                konami.input = '';
-                e.preventDefault();
-                return false;
-            }
-        },
-        load: function (link) {
-            this._currentLink = link;
-            this.addEvent(document, "keydown", this.keydownHandler, this);
-            this.iphone.load(link);
-        },
-        unload: function () {
-            this.removeEvent(document, 'keydown', this.keydownHandler);
-            this.iphone.unload();
-        },
-        code: function (link) {
-            window.location = link
-        },
-        iphone: {
-            start_x: 0,
-            start_y: 0,
-            stop_x: 0,
-            stop_y: 0,
-            tap: false,
-            capture: false,
-            orig_keys: "",
-            keys: ["UP", "UP", "DOWN", "DOWN", "LEFT", "RIGHT", "LEFT", "RIGHT", "TAP", "TAP"],
-            input: [],
-            code: function (link) {
-                konami.code(link);
-            },
-            touchmoveHandler: function (e) {
-                if (e.touches.length === 1 && konami.iphone.capture === true) {
-                    var touch = e.touches[0];
-                    konami.iphone.stop_x = touch.pageX;
-                    konami.iphone.stop_y = touch.pageY;
-                    konami.iphone.tap = false;
-                    konami.iphone.capture = false;
-                    konami.iphone.check_direction();
-                }
-            },
-            touchendHandler: function () {
-                konami.iphone.input.push(konami.iphone.check_direction());
-
-                if (konami.iphone.input.length > konami.iphone.keys.length) konami.iphone.input.shift();
-
-                if (konami.iphone.input.length === konami.iphone.keys.length) {
-                    var match = true;
-                    for (var i = 0; i < konami.iphone.keys.length; i++) {
-                        if (konami.iphone.input[i] !== konami.iphone.keys[i]) {
-                            match = false;
-                        }
-                    }
-                    if (match) {
-                        konami.iphone.code(konami._currentLink);
-                    }
-                }
-            },
-            touchstartHandler: function (e) {
-                konami.iphone.start_x = e.changedTouches[0].pageX;
-                konami.iphone.start_y = e.changedTouches[0].pageY;
-                konami.iphone.tap = true;
-                konami.iphone.capture = true;
-            },
-            load: function (link) {
-                this.orig_keys = this.keys;
-                konami.addEvent(document, "touchmove", this.touchmoveHandler);
-                konami.addEvent(document, "touchend", this.touchendHandler, false);
-                konami.addEvent(document, "touchstart", this.touchstartHandler);
-            },
-            unload: function () {
-                konami.removeEvent(document, 'touchmove', this.touchmoveHandler);
-                konami.removeEvent(document, 'touchend', this.touchendHandler);
-                konami.removeEvent(document, 'touchstart', this.touchstartHandler);
-            },
-            check_direction: function () {
-                x_magnitude = Math.abs(this.start_x - this.stop_x);
-                y_magnitude = Math.abs(this.start_y - this.stop_y);
-                x = ((this.start_x - this.stop_x) < 0) ? "RIGHT" : "LEFT";
-                y = ((this.start_y - this.stop_y) < 0) ? "DOWN" : "UP";
-                result = (x_magnitude > y_magnitude) ? x : y;
-                result = (this.tap === true) ? "TAP" : result;
-                return result;
-            }
+  var konami = {
+    addEvent: function (obj, type, fn, ref_obj) {
+      if (obj.addEventListener) obj.addEventListener(type, fn, false);
+      else if (obj.attachEvent) {
+        // IE
+        obj["e" + type + fn] = fn;
+        obj[type + fn] = function () {
+          obj["e" + type + fn](window.event, ref_obj);
+        };
+        obj.attachEvent("on" + type, obj[type + fn]);
+      }
+    },
+    removeEvent: function (obj, eventName, eventCallback) {
+      if (obj.removeEventListener) {
+        obj.removeEventListener(eventName, eventCallback);
+      } else if (obj.attachEvent) {
+        obj.detachEvent(eventName);
+      }
+    },
+    input: "",
+    pattern: "38384040373937396665",
+    keydownHandler: function (e, ref_obj) {
+      if (ref_obj) {
+        konami = ref_obj;
+      } // IE
+      konami.input += e ? e.keyCode : event.keyCode;
+      if (konami.input.length > konami.pattern.length) {
+        konami.input = konami.input.substr(
+          konami.input.length - konami.pattern.length,
+        );
+      }
+      if (konami.input === konami.pattern) {
+        konami.code(konami._currentLink);
+        konami.input = "";
+        e.preventDefault();
+        return false;
+      }
+    },
+    load: function (link) {
+      this._currentLink = link;
+      this.addEvent(document, "keydown", this.keydownHandler, this);
+      this.iphone.load(link);
+    },
+    unload: function () {
+      this.removeEvent(document, "keydown", this.keydownHandler);
+      this.iphone.unload();
+    },
+    code: function (link) {
+      window.location = link;
+    },
+    iphone: {
+      start_x: 0,
+      start_y: 0,
+      stop_x: 0,
+      stop_y: 0,
+      tap: false,
+      capture: false,
+      orig_keys: "",
+      keys: [
+        "UP",
+        "UP",
+        "DOWN",
+        "DOWN",
+        "LEFT",
+        "RIGHT",
+        "LEFT",
+        "RIGHT",
+        "TAP",
+        "TAP",
+      ],
+      input: [],
+      code: function (link) {
+        konami.code(link);
+      },
+      touchmoveHandler: function (e) {
+        if (e.touches.length === 1 && konami.iphone.capture === true) {
+          var touch = e.touches[0];
+          konami.iphone.stop_x = touch.pageX;
+          konami.iphone.stop_y = touch.pageY;
+          konami.iphone.tap = false;
+          konami.iphone.capture = false;
+          konami.iphone.check_direction();
         }
-    }
+      },
+      touchendHandler: function () {
+        konami.iphone.input.push(konami.iphone.check_direction());
 
-    typeof callback === "string" && konami.load(callback);
-    if (typeof callback === "function") {
-        konami.code = callback;
-        konami.load();
-    }
+        if (konami.iphone.input.length > konami.iphone.keys.length)
+          konami.iphone.input.shift();
 
-    return konami;
+        if (konami.iphone.input.length === konami.iphone.keys.length) {
+          var match = true;
+          for (var i = 0; i < konami.iphone.keys.length; i++) {
+            if (konami.iphone.input[i] !== konami.iphone.keys[i]) {
+              match = false;
+            }
+          }
+          if (match) {
+            konami.iphone.code(konami._currentLink);
+          }
+        }
+      },
+      touchstartHandler: function (e) {
+        konami.iphone.start_x = e.changedTouches[0].pageX;
+        konami.iphone.start_y = e.changedTouches[0].pageY;
+        konami.iphone.tap = true;
+        konami.iphone.capture = true;
+      },
+      load: function (link) {
+        this.orig_keys = this.keys;
+        konami.addEvent(document, "touchmove", this.touchmoveHandler);
+        konami.addEvent(document, "touchend", this.touchendHandler, false);
+        konami.addEvent(document, "touchstart", this.touchstartHandler);
+      },
+      unload: function () {
+        konami.removeEvent(document, "touchmove", this.touchmoveHandler);
+        konami.removeEvent(document, "touchend", this.touchendHandler);
+        konami.removeEvent(document, "touchstart", this.touchstartHandler);
+      },
+      check_direction: function () {
+        x_magnitude = Math.abs(this.start_x - this.stop_x);
+        y_magnitude = Math.abs(this.start_y - this.stop_y);
+        x = this.start_x - this.stop_x < 0 ? "RIGHT" : "LEFT";
+        y = this.start_y - this.stop_y < 0 ? "DOWN" : "UP";
+        result = x_magnitude > y_magnitude ? x : y;
+        result = this.tap === true ? "TAP" : result;
+        return result;
+      },
+    },
+  };
+
+  typeof callback === "string" && konami.load(callback);
+  if (typeof callback === "function") {
+    konami.code = callback;
+    konami.load();
+  }
+
+  return konami;
 };
 
-
-if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
-        module.exports = Konami;
+if (typeof module !== "undefined" && typeof module.exports !== "undefined") {
+  module.exports = Konami;
 } else {
-        if (typeof define === 'function' && define.amd) {
-                define([], function() {
-                        return Konami;
-                });
-        } else {
-                window.Konami = Konami;
-        }
+  if (typeof define === "function" && define.amd) {
+    define([], function () {
+      return Konami;
+    });
+  } else {
+    window.Konami = Konami;
+  }
 }

--- a/konami.js
+++ b/konami.js
@@ -4,7 +4,7 @@
  * :: those situations that call for multiple easter eggs!
  * Code: https://github.com/georgemandis/konami-js
  * Copyright (c) 2009 George Mandis (https://george.mand.is)
- * Version: 1.6.3 (11/11/2021)
+ * Version: 1.7.0 (09/03/2024)
  * Licensed under the MIT License (http://opensource.org/licenses/MIT)
  * Tested in: Safari 4+, Google Chrome 4+, Firefox 3+, IE7+, Mobile Safari 2.2.1+ and Android
  */
@@ -91,7 +91,6 @@ var Konami = function (callback) {
           konami.iphone.stop_y = touch.pageY;
           konami.iphone.tap = false;
           konami.iphone.capture = false;
-          konami.iphone.check_direction();
         }
       },
       touchendHandler: function () {
@@ -130,12 +129,14 @@ var Konami = function (callback) {
         konami.removeEvent(document, "touchstart", this.touchstartHandler);
       },
       check_direction: function () {
-        x_magnitude = Math.abs(this.start_x - this.stop_x);
-        y_magnitude = Math.abs(this.start_y - this.stop_y);
-        x = this.start_x - this.stop_x < 0 ? "RIGHT" : "LEFT";
-        y = this.start_y - this.stop_y < 0 ? "DOWN" : "UP";
-        result = x_magnitude > y_magnitude ? x : y;
-        result = this.tap === true ? "TAP" : result;
+        var x_magnitude = Math.abs(this.start_x - this.stop_x);
+        var y_magnitude = Math.abs(this.start_y - this.stop_y);
+        var x = this.start_x - this.stop_x < 0 ? "RIGHT" : "LEFT";
+        var y = this.start_y - this.stop_y < 0 ? "DOWN" : "UP";
+
+        var result =
+          this.tap === true ? "TAP" : x_magnitude > y_magnitude ? x : y;
+
         return result;
       },
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test",
     "tests"
   ],
-  "version": "1.6.3",
+  "version": "1.7.0",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Fixes issue #61 — Konami-JS doesn't play nicely when imported as a module in modern JavaScript!

The fix was quick—cleaning up my super-sloppy code from 2009 and don't pollute the global namespace with these variables (i.e. add `var` in front of them). 